### PR TITLE
Repository周りの整理

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B636A8F12B749DD40084CD0A /* GitHubRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A8F02B749DD40084CD0A /* GitHubRepository.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -37,6 +38,7 @@
 
 /* Begin PBXFileReference section */
 		B636A8EE2B748B720084CD0A /* UnitTest.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTest.xctestplan; sourceTree = "<group>"; };
+		B636A8F02B749DD40084CD0A /* GitHubRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepository.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -107,6 +109,7 @@
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
 				BFD945E2244DC5E80012785A /* MainViewController.swift */,
 				BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */,
+				B636A8F02B749DD40084CD0A /* GitHubRepository.swift */,
 				BFD945E4244DC5E80012785A /* Main.storyboard */,
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
 				BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */,
@@ -288,6 +291,7 @@
 			files = (
 				BFD945E3244DC5E80012785A /* MainViewController.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */,
+				B636A8F12B749DD40084CD0A /* GitHubRepository.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 			);

--- a/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
+++ b/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
@@ -66,7 +66,7 @@
         <!--Detail View Controller-->
         <scene sceneID="JOC-74-7VT">
             <objects>
-                <viewController id="AHY-RL-7mG" customClass="DetailViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Detail" id="AHY-RL-7mG" customClass="DetailViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="4gp-25-lRZ">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -9,32 +9,30 @@ class DetailViewController: UIViewController {
     @IBOutlet weak var forksLabel: UILabel!
     @IBOutlet weak var issuesLabel: UILabel!
 
-    var repository: [String: Any]!
+    var repository: GitHubRepository!
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        languageLabel.text = "Written in \(repository["language"] as? String ?? "")"
-        starsLabel.text = "\(repository["stargazers_count"] as? Int ?? 0) stars"
-        watchersLabel.text = "\(repository["wachers_count"] as? Int ?? 0) watchers"
-        forksLabel.text = "\(repository["forks_count"] as? Int ?? 0) forks"
-        issuesLabel.text = "\(repository["open_issues_count"] as? Int ?? 0) open issues"
-        titleLabel.text = repository["full_name"] as? String
+        languageLabel.text = "Written in \(repository.language ?? "")"
+        starsLabel.text = "\(repository.stargazersCount ?? 0) stars"
+        watchersLabel.text = "\(repository.wachersCount ?? 0) watchers"
+        forksLabel.text = "\(repository.forksCount ?? 0) forks"
+        issuesLabel.text = "\(repository.openIssuesCount ?? 0) open issues"
+        titleLabel.text = repository.fullName
         getImage()
     }
 
     func getImage() {
-        if let owner = repository["owner"] as? [String: Any] {
-            if let urlString = owner["avatar_url"] as? String, let url = URL(string: urlString) {
-                URLSession.shared.dataTask(with: url) { [weak self] (data, _, _) in
-                    guard let data, let image = UIImage(data: data) else {
-                        return
-                    }
-                    DispatchQueue.main.async {
-                        self?.imageView.image = image
-                    }
-                }.resume()
-            }
+        if let urlString = repository.owner?.avatarUrl, let url = URL(string: urlString) {
+            URLSession.shared.dataTask(with: url) { [weak self] (data, _, _) in
+                guard let data, let image = UIImage(data: data) else {
+                    return
+                }
+                DispatchQueue.main.async {
+                    self?.imageView.image = image
+                }
+            }.resume()
         }
     }
 }

--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -16,7 +16,7 @@ class DetailViewController: UIViewController {
 
         languageLabel.text = "Written in \(repository.language ?? "")"
         starsLabel.text = "\(repository.stargazersCount ?? 0) stars"
-        watchersLabel.text = "\(repository.wachersCount ?? 0) watchers"
+        watchersLabel.text = "\(repository.watchersCount ?? 0) watchers"
         forksLabel.text = "\(repository.forksCount ?? 0) forks"
         issuesLabel.text = "\(repository.openIssuesCount ?? 0) open issues"
         titleLabel.text = repository.fullName

--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -9,12 +9,10 @@ class DetailViewController: UIViewController {
     @IBOutlet weak var forksLabel: UILabel!
     @IBOutlet weak var issuesLabel: UILabel!
 
-    var mainVC: MainViewController!
+    var repository: [String: Any]!
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let repository = mainVC.repositories[mainVC.selectedIndex]
 
         languageLabel.text = "Written in \(repository["language"] as? String ?? "")"
         starsLabel.text = "\(repository["stargazers_count"] as? Int ?? 0) stars"
@@ -26,8 +24,6 @@ class DetailViewController: UIViewController {
     }
 
     func getImage() {
-        let repository = mainVC.repositories[mainVC.selectedIndex]
-
         if let owner = repository["owner"] as? [String: Any] {
             if let urlString = owner["avatar_url"] as? String, let url = URL(string: urlString) {
                 URLSession.shared.dataTask(with: url) { [weak self] (data, _, _) in

--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -9,7 +9,24 @@ class DetailViewController: UIViewController {
     @IBOutlet weak var forksLabel: UILabel!
     @IBOutlet weak var issuesLabel: UILabel!
 
-    var repository: GitHubRepository!
+    let repository: GitHubRepository
+
+    static func make(repository: GitHubRepository) -> DetailViewController {
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        let detail = storyboard.instantiateViewController(identifier: "Detail") { coder in
+            DetailViewController(coder: coder, repository: repository)
+        }
+        return detail
+    }
+
+    required init?(coder: NSCoder, repository: GitHubRepository) {
+        self.repository = repository
+        super.init(coder: coder)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/iOSEngineerCodeCheck/GitHubRepository.swift
+++ b/iOSEngineerCodeCheck/GitHubRepository.swift
@@ -9,7 +9,7 @@ struct GitHubRepository: Decodable {
     let language: String?
     let owner: GitHubOwner?
     let stargazersCount: Int?
-    let wachersCount: Int?
+    let watchersCount: Int?
     let forksCount: Int?
     let openIssuesCount: Int?
 }

--- a/iOSEngineerCodeCheck/GitHubRepository.swift
+++ b/iOSEngineerCodeCheck/GitHubRepository.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct GitHubRepository: Decodable {
+    let fullName: String?
+    let language: String?
+    let owner: GitHubOwner?
+    let stargazersCount: Int?
+    let wachersCount: Int?
+    let forksCount: Int?
+    let openIssuesCount: Int?
+}
+
+struct GitHubOwner: Decodable {
+    let avatarUrl: String?
+}

--- a/iOSEngineerCodeCheck/GitHubRepository.swift
+++ b/iOSEngineerCodeCheck/GitHubRepository.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+struct GitHubRepositories: Decodable {
+    let items: [GitHubRepository]?
+}
+
 struct GitHubRepository: Decodable {
     let fullName: String?
     let language: String?

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -50,7 +50,7 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "Detail", let detail = segue.destination as? DetailViewController {
-            detail.mainVC = self
+            detail.repository = repositories[selectedIndex]
         }
     }
 

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -52,12 +52,6 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
         }
     }
 
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "Detail", let detail = segue.destination as? DetailViewController {
-            detail.repository = repositories[selectedIndex]
-        }
-    }
-
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return repositories.count
     }
@@ -75,8 +69,8 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // 画面遷移時に呼ばれる
-        selectedIndex = indexPath.row
-        performSegue(withIdentifier: "Detail", sender: self)
+        let repository = repositories[indexPath.row]
+        let detail = DetailViewController.make(repository: repository)
+        navigationController?.pushViewController(detail, animated: true)
     }
 }


### PR DESCRIPTION
Repository周りを整理します。

* Dicitonaryではなく型を定義して使う
* 通信のレスポンスでDecodableで変換する
* `watchers_count`がTypoしていて取得できていなかったのを修正
* DetailVCを直接生成し、repositoryをletで保持する