### PR TITLE
画像をダウンロードの処理を別クラスに分割

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		B636A8F12B749DD40084CD0A /* GitHubRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A8F02B749DD40084CD0A /* GitHubRepository.swift */; };
+		B636A8F32B74AA9A0084CD0A /* ImageDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A8F22B74AA9A0084CD0A /* ImageDownloader.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -39,6 +40,7 @@
 /* Begin PBXFileReference section */
 		B636A8EE2B748B720084CD0A /* UnitTest.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTest.xctestplan; sourceTree = "<group>"; };
 		B636A8F02B749DD40084CD0A /* GitHubRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepository.swift; sourceTree = "<group>"; };
+		B636A8F22B74AA9A0084CD0A /* ImageDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloader.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -110,6 +112,7 @@
 				BFD945E2244DC5E80012785A /* MainViewController.swift */,
 				BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */,
 				B636A8F02B749DD40084CD0A /* GitHubRepository.swift */,
+				B636A8F22B74AA9A0084CD0A /* ImageDownloader.swift */,
 				BFD945E4244DC5E80012785A /* Main.storyboard */,
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
 				BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */,
@@ -293,6 +296,7 @@
 				BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */,
 				B636A8F12B749DD40084CD0A /* GitHubRepository.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
+				B636A8F32B74AA9A0084CD0A /* ImageDownloader.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -43,10 +43,10 @@ class DetailViewController: UIViewController {
     }
 
     func getImage() {
-        if let urlString = repository.owner?.avatarUrl, let url = URL(string: urlString) {
-            Task {
-                self.imageView.image = try await imageDownloader.download(from: url)
-            }
+        guard let url = repository.avatarUrl else { return }
+
+        Task {
+            self.imageView.image = try await imageDownloader.download(from: url)
         }
     }
 }

--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -10,6 +10,7 @@ class DetailViewController: UIViewController {
     @IBOutlet weak var issuesLabel: UILabel!
 
     let repository: GitHubRepository
+    let imageDownloader: ImageDownloader = .init()
 
     static func make(repository: GitHubRepository) -> DetailViewController {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
@@ -37,19 +38,15 @@ class DetailViewController: UIViewController {
         forksLabel.text = "\(repository.forksCount ?? 0) forks"
         issuesLabel.text = "\(repository.openIssuesCount ?? 0) open issues"
         titleLabel.text = repository.fullName
+
         getImage()
     }
 
     func getImage() {
         if let urlString = repository.owner?.avatarUrl, let url = URL(string: urlString) {
-            URLSession.shared.dataTask(with: url) { [weak self] (data, _, _) in
-                guard let data, let image = UIImage(data: data) else {
-                    return
-                }
-                DispatchQueue.main.async {
-                    self?.imageView.image = image
-                }
-            }.resume()
+            Task {
+                self.imageView.image = try await imageDownloader.download(from: url)
+            }
         }
     }
 }

--- a/iOSEngineerCodeCheck/GitHubRepository.swift
+++ b/iOSEngineerCodeCheck/GitHubRepository.swift
@@ -17,3 +17,12 @@ struct GitHubRepository: Decodable {
 struct GitHubOwner: Decodable {
     let avatarUrl: String?
 }
+
+extension GitHubRepository {
+    var avatarUrl: URL? {
+        guard let urlString = owner?.avatarUrl, let url = URL(string: urlString) else {
+            return nil
+        }
+        return url
+    }
+}

--- a/iOSEngineerCodeCheck/ImageDownloader.swift
+++ b/iOSEngineerCodeCheck/ImageDownloader.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+import class UIKit.UIImage
+
+final class ImageDownloader {
+    enum DownloadError: Error {
+        case dataConvertFailed
+    }
+
+    func download(from url: URL) async throws -> UIImage {
+        let (data, _) = try await URLSession.shared.data(from: url)
+
+        guard let image = UIImage(data: data) else {
+            throw DownloadError.dataConvertFailed
+        }
+
+        return image
+    }
+}

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -10,7 +10,6 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
     }
 
     var task: URLSessionTask?
-    var selectedIndex: Int!
 
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
画像ダウンロードの処理をVCから分割します。またSwift Concurrencyを使ってよりコードがシンプルに実装できるようにします。 #5 関連の変更です。