### PR TITLE
リポジトリのデータ取得を別クラスに分割

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		B636A8F12B749DD40084CD0A /* GitHubRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A8F02B749DD40084CD0A /* GitHubRepository.swift */; };
 		B636A8F32B74AA9A0084CD0A /* ImageDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A8F22B74AA9A0084CD0A /* ImageDownloader.swift */; };
+		B636A8F52B74B6720084CD0A /* GitHubAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A8F42B74B6720084CD0A /* GitHubAPIClient.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -41,6 +42,7 @@
 		B636A8EE2B748B720084CD0A /* UnitTest.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTest.xctestplan; sourceTree = "<group>"; };
 		B636A8F02B749DD40084CD0A /* GitHubRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepository.swift; sourceTree = "<group>"; };
 		B636A8F22B74AA9A0084CD0A /* ImageDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloader.swift; sourceTree = "<group>"; };
+		B636A8F42B74B6720084CD0A /* GitHubAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIClient.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 				BFD945E2244DC5E80012785A /* MainViewController.swift */,
 				BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */,
 				B636A8F02B749DD40084CD0A /* GitHubRepository.swift */,
+				B636A8F42B74B6720084CD0A /* GitHubAPIClient.swift */,
 				B636A8F22B74AA9A0084CD0A /* ImageDownloader.swift */,
 				BFD945E4244DC5E80012785A /* Main.storyboard */,
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
@@ -296,6 +299,7 @@
 				BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */,
 				B636A8F12B749DD40084CD0A /* GitHubRepository.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
+				B636A8F52B74B6720084CD0A /* GitHubAPIClient.swift in Sources */,
 				B636A8F32B74AA9A0084CD0A /* ImageDownloader.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 			);

--- a/iOSEngineerCodeCheck/GitHubAPIClient.swift
+++ b/iOSEngineerCodeCheck/GitHubAPIClient.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+actor GitHubAPIClient {
+    enum FetchError: Error {
+        case makeUrlFailed
+    }
+
+    func fetchRepositories(word: String) async throws -> [GitHubRepository] {
+        guard let url = URL(string: "https://api.github.com/search/repositories?q=\(word)") else {
+            throw FetchError.makeUrlFailed
+        }
+
+        let (data, _) = try await URLSession.shared.data(for: .init(url: url))
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let repositories = try decoder.decode(GitHubRepositories.self, from: data)
+
+        return repositories.items ?? []
+    }
+}

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -9,7 +9,8 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
         }
     }
 
-    var task: URLSessionTask?
+    let githubAPIClient: GitHubAPIClient = .init()
+    var task: Task<Void, Error>?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,28 +27,9 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
         let word = searchBar.text ?? ""
 
         if word.count > 0 {
-            guard let url = URL(string: "https://api.github.com/search/repositories?q=\(word)")
-            else {
-                return
+            task = Task {
+                self.repositories = try await githubAPIClient.fetchRepositories(word: word)
             }
-            let task = URLSession.shared.dataTask(with: url) { [weak self] (data, _, _) in
-                guard let data else { return }
-
-                let decoder = JSONDecoder()
-                decoder.keyDecodingStrategy = .convertFromSnakeCase
-
-                guard let repositories = try? decoder.decode(GitHubRepositories.self, from: data)
-                else {
-                    return
-                }
-
-                DispatchQueue.main.async {
-                    self?.repositories = repositories.items ?? []
-                }
-            }
-            self.task = task
-            // これ呼ばなきゃリストが更新されません
-            task.resume()
         }
     }
 

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -21,6 +21,7 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
 
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         task?.cancel()
+        task = nil
     }
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {


### PR DESCRIPTION
GitHubリポジトリのデータ取得処理をVCから別クラスに分割します。また、Swift Concurrencyを使ってよりシンプルに実装ができるようにします。 #4 #5 あたりの変更です。