### PR TITLE
MainVCのコードを整理

### DIFF
--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class MainViewController: UITableViewController, UISearchBarDelegate {
+class MainViewController: UITableViewController {
     @IBOutlet weak var searchBar: UISearchBar!
 
     var repositories: [GitHubRepository] = [] {
@@ -17,21 +17,6 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
         // Do any additional setup after loading the view.
         searchBar.placeholder = "GitHubのリポジトリを検索できるよー"
         searchBar.delegate = self
-    }
-
-    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        task?.cancel()
-        task = nil
-    }
-
-    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        let word = searchBar.text ?? ""
-
-        if word.count > 0 {
-            task = Task {
-                self.repositories = try await githubAPIClient.fetchRepositories(word: word)
-            }
-        }
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -54,5 +39,22 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
         let repository = repositories[indexPath.row]
         let detail = DetailViewController.make(repository: repository)
         navigationController?.pushViewController(detail, animated: true)
+    }
+}
+
+extension MainViewController: UISearchBarDelegate {
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        task?.cancel()
+        task = nil
+    }
+
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        let word = searchBar.text ?? ""
+
+        if word.count > 0 {
+            task = Task {
+                self.repositories = try await githubAPIClient.fetchRepositories(word: word)
+            }
+        }
     }
 }

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -32,7 +32,6 @@ class MainViewController: UITableViewController {
         cell.detailTextLabel?.text = repository.language
         cell.tag = indexPath.row
         return cell
-
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -27,14 +27,20 @@ class MainViewController: UITableViewController {
         -> UITableViewCell
     {
         let cell = UITableViewCell()
-        let repository = repositories[indexPath.row]
-        cell.textLabel?.text = repository.fullName
-        cell.detailTextLabel?.text = repository.language
-        cell.tag = indexPath.row
+
+        if indexPath.row < repositories.count {
+            let repository = repositories[indexPath.row]
+            cell.textLabel?.text = repository.fullName
+            cell.detailTextLabel?.text = repository.language
+            cell.tag = indexPath.row
+        }
+
         return cell
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard indexPath.row < repositories.count else { return }
+
         let repository = repositories[indexPath.row]
         let detail = DetailViewController.make(repository: repository)
         navigationController?.pushViewController(detail, animated: true)


### PR DESCRIPTION
MainViewControllerのコードを一旦整理します。

メインスレッドの状態などによってTableViewのdidSelectRow〜でデータの範囲外のrowが来ることがあるので、少なくともrepositoriesの範囲内であることはチェックしてクラッシュしないようにします。