### PR TITLE
GitHubRepositoryのテストを追加

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		B636A8FD2B74FC5B0084CD0A /* ImageCacheStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A8FC2B74FC5B0084CD0A /* ImageCacheStateTests.swift */; };
 		B636A8FF2B75006C0084CD0A /* ImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A8FE2B75006C0084CD0A /* ImageCacheTests.swift */; };
 		B636A9012B7506920084CD0A /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9002B7506920084CD0A /* TestError.swift */; };
+		B636A9072B766A320084CD0A /* GitHubRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9062B766A320084CD0A /* GitHubRepositoryTests.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -52,6 +53,7 @@
 		B636A8FC2B74FC5B0084CD0A /* ImageCacheStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheStateTests.swift; sourceTree = "<group>"; };
 		B636A8FE2B75006C0084CD0A /* ImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheTests.swift; sourceTree = "<group>"; };
 		B636A9002B7506920084CD0A /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
+		B636A9062B766A320084CD0A /* GitHubRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryTests.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 			children = (
 				B636A8FC2B74FC5B0084CD0A /* ImageCacheStateTests.swift */,
 				B636A8FE2B75006C0084CD0A /* ImageCacheTests.swift */,
+				B636A9062B766A320084CD0A /* GitHubRepositoryTests.swift */,
 				B636A9002B7506920084CD0A /* TestError.swift */,
 				BFD945F7244DC5EB0012785A /* Info.plist */,
 			);
@@ -323,6 +326,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B636A9072B766A320084CD0A /* GitHubRepositoryTests.swift in Sources */,
 				B636A8FF2B75006C0084CD0A /* ImageCacheTests.swift in Sources */,
 				B636A9012B7506920084CD0A /* TestError.swift in Sources */,
 				B636A8FD2B74FC5B0084CD0A /* ImageCacheStateTests.swift in Sources */,

--- a/iOSEngineerCodeCheckTests/GitHubRepositoryTests.swift
+++ b/iOSEngineerCodeCheckTests/GitHubRepositoryTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+@testable import iOSEngineerCodeCheck
+
+final class GitHubRepositoryTests: XCTestCase {
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func test_avatarUrl() {
+        XCTContext.runActivity(named: "ownerのavatarUrlが正しければURLを返す") { _ in
+            let owner = GitHubOwner(avatarUrl: "https://example.com/")
+            let repository = GitHubRepository(
+                fullName: nil, language: nil, owner: owner, stargazersCount: nil,
+                watchersCount: nil,
+                forksCount: nil, openIssuesCount: nil)
+
+            XCTAssertEqual(repository.avatarUrl?.absoluteString, "https://example.com/")
+        }
+
+        XCTContext.runActivity(named: "ownerのavatarUrlが不正ならnilを返す") { _ in
+            let owner = GitHubOwner(avatarUrl: "")
+            let repository = GitHubRepository(
+                fullName: nil, language: nil, owner: owner, stargazersCount: nil,
+                watchersCount: nil,
+                forksCount: nil, openIssuesCount: nil)
+
+            XCTAssertNil(repository.avatarUrl)
+        }
+
+        XCTContext.runActivity(named: "ownerがnilならnilを返す") { _ in
+            let repository = GitHubRepository(
+                fullName: nil, language: nil, owner: nil, stargazersCount: nil, watchersCount: nil,
+                forksCount: nil, openIssuesCount: nil)
+
+            XCTAssertNil(repository.avatarUrl)
+        }
+    }
+}


### PR DESCRIPTION
#9 の変更。
GitHubRepositoryの計算型プロパティのテストを追加します。