### PR TITLE
GitHubリポジトリの検索処理を別クラスに分割

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		B636A8FF2B75006C0084CD0A /* ImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A8FE2B75006C0084CD0A /* ImageCacheTests.swift */; };
 		B636A9012B7506920084CD0A /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9002B7506920084CD0A /* TestError.swift */; };
 		B636A9072B766A320084CD0A /* GitHubRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9062B766A320084CD0A /* GitHubRepositoryTests.swift */; };
+		B636A90D2B76F40B0084CD0A /* GitHubSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A90C2B76F40B0084CD0A /* GitHubSearcher.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -54,6 +55,7 @@
 		B636A8FE2B75006C0084CD0A /* ImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheTests.swift; sourceTree = "<group>"; };
 		B636A9002B7506920084CD0A /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		B636A9062B766A320084CD0A /* GitHubRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryTests.swift; sourceTree = "<group>"; };
+		B636A90C2B76F40B0084CD0A /* GitHubSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearcher.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 				BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */,
 				B636A8F82B74F3730084CD0A /* ImageCache.swift */,
 				B636A8FA2B74FB400084CD0A /* ImageCacheState.swift */,
+				B636A90C2B76F40B0084CD0A /* GitHubSearcher.swift */,
 				B636A8F02B749DD40084CD0A /* GitHubRepository.swift */,
 				B636A8F42B74B6720084CD0A /* GitHubAPIClient.swift */,
 				B636A8F22B74AA9A0084CD0A /* ImageDownloader.swift */,
@@ -312,6 +315,7 @@
 			files = (
 				BFD945E3244DC5E80012785A /* MainViewController.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */,
+				B636A90D2B76F40B0084CD0A /* GitHubSearcher.swift in Sources */,
 				B636A8F92B74F3730084CD0A /* ImageCache.swift in Sources */,
 				B636A8F12B749DD40084CD0A /* GitHubRepository.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		B636A9012B7506920084CD0A /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9002B7506920084CD0A /* TestError.swift */; };
 		B636A9072B766A320084CD0A /* GitHubRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9062B766A320084CD0A /* GitHubRepositoryTests.swift */; };
 		B636A90D2B76F40B0084CD0A /* GitHubSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A90C2B76F40B0084CD0A /* GitHubSearcher.swift */; };
+		B636A90F2B76FA9C0084CD0A /* GitHubSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A90E2B76FA9C0084CD0A /* GitHubSearcherTests.swift */; };
+		B636A9132B76FC0F0084CD0A /* GitHubRepositoryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9122B76FC0F0084CD0A /* GitHubRepositoryExtension.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -56,6 +58,8 @@
 		B636A9002B7506920084CD0A /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		B636A9062B766A320084CD0A /* GitHubRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryTests.swift; sourceTree = "<group>"; };
 		B636A90C2B76F40B0084CD0A /* GitHubSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearcher.swift; sourceTree = "<group>"; };
+		B636A90E2B76FA9C0084CD0A /* GitHubSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearcherTests.swift; sourceTree = "<group>"; };
+		B636A9122B76FC0F0084CD0A /* GitHubRepositoryExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryExtension.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -145,7 +149,9 @@
 				B636A8FC2B74FC5B0084CD0A /* ImageCacheStateTests.swift */,
 				B636A8FE2B75006C0084CD0A /* ImageCacheTests.swift */,
 				B636A9062B766A320084CD0A /* GitHubRepositoryTests.swift */,
+				B636A90E2B76FA9C0084CD0A /* GitHubSearcherTests.swift */,
 				B636A9002B7506920084CD0A /* TestError.swift */,
+				B636A9122B76FC0F0084CD0A /* GitHubRepositoryExtension.swift */,
 				BFD945F7244DC5EB0012785A /* Info.plist */,
 			);
 			path = iOSEngineerCodeCheckTests;
@@ -330,9 +336,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B636A9132B76FC0F0084CD0A /* GitHubRepositoryExtension.swift in Sources */,
 				B636A9072B766A320084CD0A /* GitHubRepositoryTests.swift in Sources */,
 				B636A8FF2B75006C0084CD0A /* ImageCacheTests.swift in Sources */,
 				B636A9012B7506920084CD0A /* TestError.swift in Sources */,
+				B636A90F2B76FA9C0084CD0A /* GitHubSearcherTests.swift in Sources */,
 				B636A8FD2B74FC5B0084CD0A /* ImageCacheStateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		B636A90D2B76F40B0084CD0A /* GitHubSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A90C2B76F40B0084CD0A /* GitHubSearcher.swift */; };
 		B636A90F2B76FA9C0084CD0A /* GitHubSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A90E2B76FA9C0084CD0A /* GitHubSearcherTests.swift */; };
 		B636A9132B76FC0F0084CD0A /* GitHubRepositoryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9122B76FC0F0084CD0A /* GitHubRepositoryExtension.swift */; };
+		B636A9152B770EBB0084CD0A /* GitHubSearcherState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9142B770EBB0084CD0A /* GitHubSearcherState.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -60,6 +61,7 @@
 		B636A90C2B76F40B0084CD0A /* GitHubSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearcher.swift; sourceTree = "<group>"; };
 		B636A90E2B76FA9C0084CD0A /* GitHubSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearcherTests.swift; sourceTree = "<group>"; };
 		B636A9122B76FC0F0084CD0A /* GitHubRepositoryExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryExtension.swift; sourceTree = "<group>"; };
+		B636A9142B770EBB0084CD0A /* GitHubSearcherState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearcherState.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 				B636A8F82B74F3730084CD0A /* ImageCache.swift */,
 				B636A8FA2B74FB400084CD0A /* ImageCacheState.swift */,
 				B636A90C2B76F40B0084CD0A /* GitHubSearcher.swift */,
+				B636A9142B770EBB0084CD0A /* GitHubSearcherState.swift */,
 				B636A8F02B749DD40084CD0A /* GitHubRepository.swift */,
 				B636A8F42B74B6720084CD0A /* GitHubAPIClient.swift */,
 				B636A8F22B74AA9A0084CD0A /* ImageDownloader.swift */,
@@ -321,6 +324,7 @@
 			files = (
 				BFD945E3244DC5E80012785A /* MainViewController.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */,
+				B636A9152B770EBB0084CD0A /* GitHubSearcherState.swift in Sources */,
 				B636A90D2B76F40B0084CD0A /* GitHubSearcher.swift in Sources */,
 				B636A8F92B74F3730084CD0A /* ImageCache.swift in Sources */,
 				B636A8F12B749DD40084CD0A /* GitHubRepository.swift in Sources */,

--- a/iOSEngineerCodeCheck/GitHubAPIClient.swift
+++ b/iOSEngineerCodeCheck/GitHubAPIClient.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-actor GitHubAPIClient {
+actor GitHubAPIClient: GitHubAPIClientForSearcher {
     enum FetchError: Error {
         case makeUrlFailed
     }

--- a/iOSEngineerCodeCheck/GitHubRepository.swift
+++ b/iOSEngineerCodeCheck/GitHubRepository.swift
@@ -4,7 +4,7 @@ struct GitHubRepositories: Decodable {
     let items: [GitHubRepository]?
 }
 
-struct GitHubRepository: Decodable {
+struct GitHubRepository: Decodable, Equatable {
     let fullName: String?
     let language: String?
     let owner: GitHubOwner?
@@ -14,7 +14,7 @@ struct GitHubRepository: Decodable {
     let openIssuesCount: Int?
 }
 
-struct GitHubOwner: Decodable {
+struct GitHubOwner: Decodable, Equatable {
     let avatarUrl: String?
 }
 

--- a/iOSEngineerCodeCheck/GitHubSearcher.swift
+++ b/iOSEngineerCodeCheck/GitHubSearcher.swift
@@ -1,9 +1,13 @@
 import Combine
 import Foundation
 
+protocol GitHubAPIClientForSearcher {
+    func fetchRepositories(word: String) async throws -> [GitHubRepository]
+}
+
 @MainActor
 final class GitHubSearcher {
-    private let apiClient: GitHubAPIClient = .init()
+    private let apiClient: GitHubAPIClientForSearcher
 
     private let repositoriesSubject: CurrentValueSubject<[GitHubRepository], Never> = .init([])
     var repositories: [GitHubRepository] { repositoriesSubject.value }
@@ -12,6 +16,10 @@ final class GitHubSearcher {
     }
 
     private var task: Task<Void, Error>?
+
+    init(apiClient: GitHubAPIClientForSearcher = GitHubAPIClient()) {
+        self.apiClient = apiClient
+    }
 
     func search(word: String) {
         guard word.count > 0 else { return }

--- a/iOSEngineerCodeCheck/GitHubSearcher.swift
+++ b/iOSEngineerCodeCheck/GitHubSearcher.swift
@@ -1,0 +1,31 @@
+import Combine
+import Foundation
+
+@MainActor
+final class GitHubSearcher {
+    private let apiClient: GitHubAPIClient = .init()
+
+    private let repositoriesSubject: CurrentValueSubject<[GitHubRepository], Never> = .init([])
+    var repositories: [GitHubRepository] { repositoriesSubject.value }
+    var repositoriesPublisher: AnyPublisher<[GitHubRepository], Never> {
+        repositoriesSubject.eraseToAnyPublisher()
+    }
+
+    private var task: Task<Void, Error>?
+
+    func search(word: String) {
+        guard word.count > 0 else { return }
+
+        cancel()
+
+        task = Task {
+            let repositories = try await apiClient.fetchRepositories(word: word)
+            repositoriesSubject.value = repositories
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+    }
+}

--- a/iOSEngineerCodeCheck/GitHubSearcher.swift
+++ b/iOSEngineerCodeCheck/GitHubSearcher.swift
@@ -28,8 +28,12 @@ final class GitHubSearcher {
         state.task?.cancel()
 
         let task = Task {
-            let repositories = try await apiClient.fetchRepositories(word: word)
-            state = .loaded(repositories)
+            do {
+                let repositories = try await apiClient.fetchRepositories(word: word)
+                state = .loaded(repositories)
+            } catch {
+                state = .failed(error, state.repositories)
+            }
         }
 
         state = .loading(task, state.repositories)

--- a/iOSEngineerCodeCheck/GitHubSearcher.swift
+++ b/iOSEngineerCodeCheck/GitHubSearcher.swift
@@ -18,11 +18,6 @@ final class GitHubSearcher {
         stateSubject.eraseToAnyPublisher()
     }
 
-    var repositories: [GitHubRepository] { state.repositories }
-    var repositoriesPublisher: AnyPublisher<[GitHubRepository], Never> {
-        stateSubject.map(\.repositories).eraseToAnyPublisher()
-    }
-
     init(apiClient: GitHubAPIClientForSearcher = GitHubAPIClient()) {
         self.apiClient = apiClient
     }
@@ -37,11 +32,11 @@ final class GitHubSearcher {
             state = .loaded(repositories)
         }
 
-        state = .loading(task, repositories)
+        state = .loading(task, state.repositories)
     }
 
     func cancel() {
         state.task?.cancel()
-        state = .loaded(repositories)
+        state = .loaded(state.repositories)
     }
 }

--- a/iOSEngineerCodeCheck/GitHubSearcherState.swift
+++ b/iOSEngineerCodeCheck/GitHubSearcherState.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum GitHubSearcherState {
     case initial
-    case loading(Task<Void, Error>, [GitHubRepository])
+    case loading(Task<Void, Never>, [GitHubRepository])
     case loaded([GitHubRepository])
     case failed(Error, [GitHubRepository])
 }
@@ -17,7 +17,7 @@ extension GitHubSearcherState {
         }
     }
 
-    var task: Task<Void, Error>? {
+    var task: Task<Void, Never>? {
         switch self {
         case .loading(let task, _):
             task

--- a/iOSEngineerCodeCheck/GitHubSearcherState.swift
+++ b/iOSEngineerCodeCheck/GitHubSearcherState.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum GitHubSearcherState {
+    case initial
+    case loading(Task<Void, Error>, [GitHubRepository])
+    case loaded([GitHubRepository])
+    case failed(Error, [GitHubRepository])
+}
+
+extension GitHubSearcherState {
+    var repositories: [GitHubRepository] {
+        switch self {
+        case .initial:
+            []
+        case .loading(_, let repositories), .loaded(let repositories), .failed(_, let repositories):
+            repositories
+        }
+    }
+
+    var task: Task<Void, Error>? {
+        switch self {
+        case .loading(let task, _):
+            task
+        case .initial, .loaded, .failed:
+            nil
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -6,7 +6,7 @@ class MainViewController: UITableViewController {
 
     private let searcher: GitHubSearcher = .init()
     private var cancellables: Set<AnyCancellable> = []
-    private var repositories: [GitHubRepository] { searcher.repositories }
+    private var repositories: [GitHubRepository] { searcher.state.repositories }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -14,7 +14,7 @@ class MainViewController: UITableViewController {
         searchBar.placeholder = "GitHubのリポジトリを検索できるよー"
         searchBar.delegate = self
 
-        searcher.repositoriesPublisher.sink { [weak self] _ in
+        searcher.statePublisher.map(\.repositories).sink { [weak self] _ in
             self?.tableView.reloadData()
         }.store(in: &cancellables)
     }

--- a/iOSEngineerCodeCheckTests/GitHubRepositoryExtension.swift
+++ b/iOSEngineerCodeCheckTests/GitHubRepositoryExtension.swift
@@ -8,4 +8,10 @@ extension GitHubRepository {
             fullName: testFullName, language: nil, owner: nil, stargazersCount: nil,
             watchersCount: nil, forksCount: nil, openIssuesCount: nil)
     }
+
+    init(owner: GitHubOwner?) {
+        self.init(
+            fullName: nil, language: nil, owner: owner, stargazersCount: nil, watchersCount: nil,
+            forksCount: nil, openIssuesCount: nil)
+    }
 }

--- a/iOSEngineerCodeCheckTests/GitHubRepositoryExtension.swift
+++ b/iOSEngineerCodeCheckTests/GitHubRepositoryExtension.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+@testable import iOSEngineerCodeCheck
+
+extension GitHubRepository {
+    init(testFullName: String) {
+        self.init(
+            fullName: testFullName, language: nil, owner: nil, stargazersCount: nil,
+            watchersCount: nil, forksCount: nil, openIssuesCount: nil)
+    }
+}

--- a/iOSEngineerCodeCheckTests/GitHubRepositoryTests.swift
+++ b/iOSEngineerCodeCheckTests/GitHubRepositoryTests.swift
@@ -12,28 +12,20 @@ final class GitHubRepositoryTests: XCTestCase {
     func test_avatarUrl() {
         XCTContext.runActivity(named: "ownerのavatarUrlが正しければURLを返す") { _ in
             let owner = GitHubOwner(avatarUrl: "https://example.com/")
-            let repository = GitHubRepository(
-                fullName: nil, language: nil, owner: owner, stargazersCount: nil,
-                watchersCount: nil,
-                forksCount: nil, openIssuesCount: nil)
+            let repository = GitHubRepository(owner: owner)
 
             XCTAssertEqual(repository.avatarUrl?.absoluteString, "https://example.com/")
         }
 
         XCTContext.runActivity(named: "ownerのavatarUrlが不正ならnilを返す") { _ in
             let owner = GitHubOwner(avatarUrl: "")
-            let repository = GitHubRepository(
-                fullName: nil, language: nil, owner: owner, stargazersCount: nil,
-                watchersCount: nil,
-                forksCount: nil, openIssuesCount: nil)
+            let repository = GitHubRepository(owner: owner)
 
             XCTAssertNil(repository.avatarUrl)
         }
 
         XCTContext.runActivity(named: "ownerがnilならnilを返す") { _ in
-            let repository = GitHubRepository(
-                fullName: nil, language: nil, owner: nil, stargazersCount: nil, watchersCount: nil,
-                forksCount: nil, openIssuesCount: nil)
+            let repository = GitHubRepository(owner: nil)
 
             XCTAssertNil(repository.avatarUrl)
         }

--- a/iOSEngineerCodeCheckTests/GitHubSearcherTests.swift
+++ b/iOSEngineerCodeCheckTests/GitHubSearcherTests.swift
@@ -71,7 +71,10 @@ final class GitHubSearcherTests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
 
         XCTAssertTrue(searcher.state.isMatch(.loaded(repositories)))
-        XCTAssertTrue(received.last?.isMatch(.loaded(repositories)) ?? false)
+
+        XCTAssertEqual(received.count, 3)
+        XCTAssertTrue(received[1].isMatch(.loading([])))
+        XCTAssertTrue(received[2].isMatch(.loaded(repositories)))
 
         canceller.cancel()
     }

--- a/iOSEngineerCodeCheckTests/GitHubSearcherTests.swift
+++ b/iOSEngineerCodeCheckTests/GitHubSearcherTests.swift
@@ -29,27 +29,27 @@ final class GitHubSearcherTests: XCTestCase {
         let apiClient = APIClientMock(result: .success(repositories))
         let searcher = GitHubSearcher(apiClient: apiClient)
 
-        var received: [[GitHubRepository]] = []
+        var received: [GitHubSearcherState] = []
         let expectation = XCTestExpectation(description: "fetched")
 
-        let canceller = searcher.repositoriesPublisher.sink { repositories in
-            received.append(repositories)
+        let canceller = searcher.statePublisher.sink { state in
+            received.append(state)
 
-            if !repositories.isEmpty {
+            if case .loaded = state {
                 expectation.fulfill()
             }
         }
 
-        XCTAssertEqual(searcher.repositories, [])
+        XCTAssertEqual(searcher.state.repositories, [])
         XCTAssertEqual(received.count, 1)
-        XCTAssertEqual(received[0], [])
+        XCTAssertEqual(received[0].repositories, [])
 
         searcher.search(word: "hoge")
 
         wait(for: [expectation], timeout: 10.0)
 
-        XCTAssertEqual(searcher.repositories, repositories)
-        XCTAssertEqual(received.last, repositories)
+        XCTAssertEqual(searcher.state.repositories, repositories)
+        XCTAssertEqual(received.last?.repositories, repositories)
 
         canceller.cancel()
     }

--- a/iOSEngineerCodeCheckTests/GitHubSearcherTests.swift
+++ b/iOSEngineerCodeCheckTests/GitHubSearcherTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+@testable import iOSEngineerCodeCheck
+
+private actor APIClientMock: GitHubAPIClientForSearcher {
+    let result: Result<[GitHubRepository], Error>
+
+    init(result: Result<[GitHubRepository], Error>) {
+        self.result = result
+    }
+
+    func fetchRepositories(word: String) async throws -> [GitHubRepository] {
+        try result.get()
+    }
+}
+
+@MainActor
+final class GitHubSearcherTests: XCTestCase {
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func test_検索が成功してデータが返る() {
+        let repositories: [GitHubRepository] = [
+            .init(testFullName: "foo"), .init(testFullName: "bar"),
+        ]
+        let apiClient = APIClientMock(result: .success(repositories))
+        let searcher = GitHubSearcher(apiClient: apiClient)
+
+        var received: [[GitHubRepository]] = []
+        let expectation = XCTestExpectation(description: "fetched")
+
+        let canceller = searcher.repositoriesPublisher.sink { repositories in
+            received.append(repositories)
+
+            if !repositories.isEmpty {
+                expectation.fulfill()
+            }
+        }
+
+        XCTAssertEqual(searcher.repositories, [])
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(received[0], [])
+
+        searcher.search(word: "hoge")
+
+        wait(for: [expectation], timeout: 10.0)
+
+        XCTAssertEqual(searcher.repositories, repositories)
+        XCTAssertEqual(received.last, repositories)
+
+        canceller.cancel()
+    }
+}

--- a/iOSEngineerCodeCheckTests/ImageCacheTests.swift
+++ b/iOSEngineerCodeCheckTests/ImageCacheTests.swift
@@ -78,7 +78,7 @@ final class ImageCacheTests: XCTestCase {
         let imageCache = ImageCache(downloader: DownloaderMock(result: .failure(TestError.dummy)))
 
         var receivedStates: [ImageCacheState] = []
-        let expectation = XCTestExpectation(description: "loaded")
+        let expectation = XCTestExpectation(description: "failed")
 
         let canceller = imageCache.statePublisher.sink { state in
             receivedStates.append(state)


### PR DESCRIPTION
#4 #5 の変更。
GitHubリポジトリを検索する処理をVCから別クラスに分割します。