### PR TITLE
NavigationController側で遷移を管理する

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		B636A9132B76FC0F0084CD0A /* GitHubRepositoryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9122B76FC0F0084CD0A /* GitHubRepositoryExtension.swift */; };
 		B636A9152B770EBB0084CD0A /* GitHubSearcherState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9142B770EBB0084CD0A /* GitHubSearcherState.swift */; };
 		B636A9172B77558E0084CD0A /* RootNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9162B77558E0084CD0A /* RootNavigationController.swift */; };
+		B636A9192B77560A0084CD0A /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9182B7756090084CD0A /* NavigationRouter.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -64,6 +65,7 @@
 		B636A9122B76FC0F0084CD0A /* GitHubRepositoryExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryExtension.swift; sourceTree = "<group>"; };
 		B636A9142B770EBB0084CD0A /* GitHubSearcherState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearcherState.swift; sourceTree = "<group>"; };
 		B636A9162B77558E0084CD0A /* RootNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationController.swift; sourceTree = "<group>"; };
+		B636A9182B7756090084CD0A /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 				BFD945DE244DC5E80012785A /* AppDelegate.swift */,
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
 				B636A9162B77558E0084CD0A /* RootNavigationController.swift */,
+				B636A9182B7756090084CD0A /* NavigationRouter.swift */,
 				BFD945E2244DC5E80012785A /* MainViewController.swift */,
 				BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */,
 				B636A8F82B74F3730084CD0A /* ImageCache.swift */,
@@ -335,6 +338,7 @@
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				B636A8F52B74B6720084CD0A /* GitHubAPIClient.swift in Sources */,
 				B636A8F32B74AA9A0084CD0A /* ImageDownloader.swift in Sources */,
+				B636A9192B77560A0084CD0A /* NavigationRouter.swift in Sources */,
 				B636A8FB2B74FB400084CD0A /* ImageCacheState.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 			);

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		B636A90F2B76FA9C0084CD0A /* GitHubSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A90E2B76FA9C0084CD0A /* GitHubSearcherTests.swift */; };
 		B636A9132B76FC0F0084CD0A /* GitHubRepositoryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9122B76FC0F0084CD0A /* GitHubRepositoryExtension.swift */; };
 		B636A9152B770EBB0084CD0A /* GitHubSearcherState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9142B770EBB0084CD0A /* GitHubSearcherState.swift */; };
+		B636A9172B77558E0084CD0A /* RootNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9162B77558E0084CD0A /* RootNavigationController.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -62,6 +63,7 @@
 		B636A90E2B76FA9C0084CD0A /* GitHubSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearcherTests.swift; sourceTree = "<group>"; };
 		B636A9122B76FC0F0084CD0A /* GitHubRepositoryExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepositoryExtension.swift; sourceTree = "<group>"; };
 		B636A9142B770EBB0084CD0A /* GitHubSearcherState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearcherState.swift; sourceTree = "<group>"; };
+		B636A9162B77558E0084CD0A /* RootNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationController.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 			children = (
 				BFD945DE244DC5E80012785A /* AppDelegate.swift */,
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
+				B636A9162B77558E0084CD0A /* RootNavigationController.swift */,
 				BFD945E2244DC5E80012785A /* MainViewController.swift */,
 				BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */,
 				B636A8F82B74F3730084CD0A /* ImageCache.swift */,
@@ -327,6 +330,7 @@
 				B636A9152B770EBB0084CD0A /* GitHubSearcherState.swift in Sources */,
 				B636A90D2B76F40B0084CD0A /* GitHubSearcher.swift in Sources */,
 				B636A8F92B74F3730084CD0A /* ImageCache.swift in Sources */,
+				B636A9172B77558E0084CD0A /* RootNavigationController.swift in Sources */,
 				B636A8F12B749DD40084CD0A /* GitHubRepository.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				B636A8F52B74B6720084CD0A /* GitHubAPIClient.swift in Sources */,

--- a/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
+++ b/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
@@ -12,7 +12,7 @@
         <!--Root View Controller-->
         <scene sceneID="0Yw-Vc-k2Q">
             <objects>
-                <tableViewController id="MOh-CZ-3ki" customClass="MainViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="Main" id="MOh-CZ-3ki" customClass="MainViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Fpt-Ev-QNW">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -54,9 +54,9 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="Root View Controller" id="ktq-eC-ZBq"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
                         <outlet property="searchBar" destination="6rq-CD-Hob" id="3gq-mK-4M3"/>
-                        <segue destination="AHY-RL-7mG" kind="show" identifier="Detail" id="qqd-8W-4W1"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xer-fe-JeW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -138,6 +138,7 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="J6o-vL-S1z"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
                         <outlet property="forksLabel" destination="ZMv-4f-X2V" id="i84-sH-c5t"/>
                         <outlet property="imageView" destination="Iim-eb-8Ad" id="dmH-tP-ZuI"/>
@@ -160,9 +161,6 @@
                         <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
-                    <connections>
-                        <segue destination="MOh-CZ-3ki" kind="relationship" relationship="rootViewController" id="tOh-FN-tGd"/>
-                    </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="scZ-hy-tAz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
+++ b/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
@@ -152,10 +152,10 @@
             </objects>
             <point key="canvasLocation" x="230" y="137"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Root Navigation Controller-->
         <scene sceneID="hWi-qa-NBR">
             <objects>
-                <navigationController id="wFt-RI-uk4" sceneMemberID="viewController">
+                <navigationController id="wFt-RI-uk4" customClass="RootNavigationController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iRk-f0-Qkc">
                         <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/iOSEngineerCodeCheck/NavigationRouter.swift
+++ b/iOSEngineerCodeCheck/NavigationRouter.swift
@@ -1,0 +1,45 @@
+import Combine
+import Foundation
+
+struct NavigationDetail {
+    let repository: GitHubRepository
+}
+
+enum NavigationElement {
+    case main
+    case detail(NavigationDetail)
+}
+
+final class NavigationRouter {
+    private let detailSubject: CurrentValueSubject<NavigationDetail?, Never> = .init(nil)
+
+    var elements: [NavigationElement] {
+        detailSubject.value.elements
+    }
+
+    var elementsPublisher: AnyPublisher<[NavigationElement], Never> {
+        detailSubject.map(\.elements).eraseToAnyPublisher()
+    }
+
+    func mainDidAppear() {
+        detailSubject.value = nil
+    }
+
+    func showDetail(_ detail: NavigationDetail) {
+        guard detailSubject.value == nil else {
+            return
+        }
+
+        detailSubject.value = detail
+    }
+}
+
+extension NavigationDetail? {
+    fileprivate var elements: [NavigationElement] {
+        if let detail = self {
+            [.main, .detail(detail)]
+        } else {
+            [.main]
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/RootNavigationController.swift
+++ b/iOSEngineerCodeCheck/RootNavigationController.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+class RootNavigationController: UINavigationController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/iOSEngineerCodeCheck/RootNavigationController.swift
+++ b/iOSEngineerCodeCheck/RootNavigationController.swift
@@ -1,7 +1,41 @@
+import Combine
 import UIKit
 
 class RootNavigationController: UINavigationController {
+    private let router: NavigationRouter = .init()
+    private var cancellables: Set<AnyCancellable> = []
+
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        router.elementsPublisher.sink { [weak self] _ in
+            self?.updateViewControllers()
+        }.store(in: &cancellables)
+    }
+
+    private func updateViewControllers() {
+        let elements = router.elements
+        let previousCount = viewControllers.count
+
+        if elements.count < previousCount {
+            setViewControllers(
+                Array(viewControllers.prefix(elements.count)), animated: true)
+        } else if previousCount < elements.count {
+            var viewControllers = viewControllers
+            for index in previousCount..<elements.count {
+                let viewController = makeViewController(element: elements[index])
+                viewControllers.append(viewController)
+            }
+            setViewControllers(viewControllers, animated: true)
+        }
+    }
+
+    private func makeViewController(element: NavigationElement) -> UIViewController {
+        switch element {
+        case .main:
+            MainViewController.make(router: router)
+        case let .detail(detail):
+            DetailViewController.make(repository: detail.repository)
+        }
     }
 }


### PR DESCRIPTION
#2 #5 などに関する変更。

ナビゲーションの遷移はUINavigationControllerが行うものなので、MainVCで遷移を呼び出すのはやめて、遷移の状態を管理する`NavigationRouter`を作り、それ経由で遷移を行うようにします。

これにより、Detailが表示されているのに重複してDetailが開くなどのバグを防ぐことができます。