### PR TITLE
NavigationRouterのテストを追加

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		B636A9152B770EBB0084CD0A /* GitHubSearcherState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9142B770EBB0084CD0A /* GitHubSearcherState.swift */; };
 		B636A9172B77558E0084CD0A /* RootNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9162B77558E0084CD0A /* RootNavigationController.swift */; };
 		B636A9192B77560A0084CD0A /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9182B7756090084CD0A /* NavigationRouter.swift */; };
+		B69AD34B2B779B6E0051CC84 /* NavigationRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD34A2B779B6E0051CC84 /* NavigationRouterTests.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -66,6 +67,7 @@
 		B636A9142B770EBB0084CD0A /* GitHubSearcherState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearcherState.swift; sourceTree = "<group>"; };
 		B636A9162B77558E0084CD0A /* RootNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationController.swift; sourceTree = "<group>"; };
 		B636A9182B7756090084CD0A /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
+		B69AD34A2B779B6E0051CC84 /* NavigationRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouterTests.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 				B636A8FE2B75006C0084CD0A /* ImageCacheTests.swift */,
 				B636A9062B766A320084CD0A /* GitHubRepositoryTests.swift */,
 				B636A90E2B76FA9C0084CD0A /* GitHubSearcherTests.swift */,
+				B69AD34A2B779B6E0051CC84 /* NavigationRouterTests.swift */,
 				B636A9002B7506920084CD0A /* TestError.swift */,
 				B636A9122B76FC0F0084CD0A /* GitHubRepositoryExtension.swift */,
 				BFD945F7244DC5EB0012785A /* Info.plist */,
@@ -348,6 +351,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B69AD34B2B779B6E0051CC84 /* NavigationRouterTests.swift in Sources */,
 				B636A9132B76FC0F0084CD0A /* GitHubRepositoryExtension.swift in Sources */,
 				B636A9072B766A320084CD0A /* GitHubRepositoryTests.swift in Sources */,
 				B636A8FF2B75006C0084CD0A /* ImageCacheTests.swift in Sources */,

--- a/iOSEngineerCodeCheck/RootNavigationController.swift
+++ b/iOSEngineerCodeCheck/RootNavigationController.swift
@@ -8,7 +8,7 @@ class RootNavigationController: UINavigationController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        router.elementsPublisher.sink { [weak self] _ in
+        router.elementsPublisher.removeDuplicates().sink { [weak self] _ in
             self?.updateViewControllers()
         }.store(in: &cancellables)
     }

--- a/iOSEngineerCodeCheckTests/NavigationRouterTests.swift
+++ b/iOSEngineerCodeCheckTests/NavigationRouterTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import iOSEngineerCodeCheck
+
+final class NavigationRouterTests: XCTestCase {
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func test_遷移() {
+        let router = NavigationRouter()
+
+        XCTAssertEqual(router.elements, [.main])
+
+        XCTContext.runActivity(named: "Mainが表示される前はDetailに遷移できない") { _ in
+            router.showDetail(.init(repository: .init(testFullName: "pre_appear")))
+
+            XCTAssertEqual(router.elements, [.main])
+        }
+
+        XCTContext.runActivity(named: "Mainが表示されたらDetailに遷移できる") { _ in
+            router.mainDidAppear()
+
+            XCTAssertEqual(router.elements, [.main])
+
+            router.showDetail(.init(repository: .init(testFullName: "main_appeared")))
+
+            XCTAssertEqual(
+                router.elements,
+                [.main, .detail(.init(repository: .init(testFullName: "main_appeared")))])
+        }
+
+        XCTContext.runActivity(named: "Detail表示中は重複して遷移できない") { _ in
+            router.showDetail(.init(repository: .init(testFullName: "detail_appeared")))
+
+            XCTAssertEqual(
+                router.elements,
+                [.main, .detail(.init(repository: .init(testFullName: "main_appeared")))])
+        }
+
+        XCTContext.runActivity(named: "Detail表示中にMainに戻る") { _ in
+            router.mainDidAppear()
+
+            XCTAssertEqual(router.elements, [.main])
+        }
+
+        XCTContext.runActivity(named: "Mainに戻ったらDetailに遷移できる") { _ in
+            router.showDetail(.init(repository: .init(testFullName: "main_appeared")))
+
+            XCTAssertEqual(
+                router.elements,
+                [.main, .detail(.init(repository: .init(testFullName: "main_appeared")))])
+        }
+    }
+}


### PR DESCRIPTION
#9 に関する変更。
NavigationRouterのテストを追加します。
また、NavigationRouterが意図的でない動作をしていたので、修正しました。