### PR TITLE
GitHubAPIClientのテストを追加

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		B636A9172B77558E0084CD0A /* RootNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9162B77558E0084CD0A /* RootNavigationController.swift */; };
 		B636A9192B77560A0084CD0A /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9182B7756090084CD0A /* NavigationRouter.swift */; };
 		B69AD34B2B779B6E0051CC84 /* NavigationRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD34A2B779B6E0051CC84 /* NavigationRouterTests.swift */; };
+		B69AD34D2B77A5F50051CC84 /* URLSessionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD34C2B77A5F50051CC84 /* URLSessionExtension.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -68,6 +69,7 @@
 		B636A9162B77558E0084CD0A /* RootNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootNavigationController.swift; sourceTree = "<group>"; };
 		B636A9182B7756090084CD0A /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
 		B69AD34A2B779B6E0051CC84 /* NavigationRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouterTests.swift; sourceTree = "<group>"; };
+		B69AD34C2B77A5F50051CC84 /* URLSessionExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionExtension.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -146,6 +148,7 @@
 				B636A8F02B749DD40084CD0A /* GitHubRepository.swift */,
 				B636A8F42B74B6720084CD0A /* GitHubAPIClient.swift */,
 				B636A8F22B74AA9A0084CD0A /* ImageDownloader.swift */,
+				B69AD34C2B77A5F50051CC84 /* URLSessionExtension.swift */,
 				BFD945E4244DC5E80012785A /* Main.storyboard */,
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
 				BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */,
@@ -339,6 +342,7 @@
 				B636A9172B77558E0084CD0A /* RootNavigationController.swift in Sources */,
 				B636A8F12B749DD40084CD0A /* GitHubRepository.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
+				B69AD34D2B77A5F50051CC84 /* URLSessionExtension.swift in Sources */,
 				B636A8F52B74B6720084CD0A /* GitHubAPIClient.swift in Sources */,
 				B636A8F32B74AA9A0084CD0A /* ImageDownloader.swift in Sources */,
 				B636A9192B77560A0084CD0A /* NavigationRouter.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		B636A9192B77560A0084CD0A /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B636A9182B7756090084CD0A /* NavigationRouter.swift */; };
 		B69AD34B2B779B6E0051CC84 /* NavigationRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD34A2B779B6E0051CC84 /* NavigationRouterTests.swift */; };
 		B69AD34D2B77A5F50051CC84 /* URLSessionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD34C2B77A5F50051CC84 /* URLSessionExtension.swift */; };
+		B69AD34F2B77A9450051CC84 /* github-repositories.json in Resources */ = {isa = PBXBuildFile; fileRef = B69AD34E2B77A9450051CC84 /* github-repositories.json */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -70,6 +71,7 @@
 		B636A9182B7756090084CD0A /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
 		B69AD34A2B779B6E0051CC84 /* NavigationRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouterTests.swift; sourceTree = "<group>"; };
 		B69AD34C2B77A5F50051CC84 /* URLSessionExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionExtension.swift; sourceTree = "<group>"; };
+		B69AD34E2B77A9450051CC84 /* github-repositories.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "github-repositories.json"; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -167,6 +169,7 @@
 				B69AD34A2B779B6E0051CC84 /* NavigationRouterTests.swift */,
 				B636A9002B7506920084CD0A /* TestError.swift */,
 				B636A9122B76FC0F0084CD0A /* GitHubRepositoryExtension.swift */,
+				B69AD34E2B77A9450051CC84 /* github-repositories.json */,
 				BFD945F7244DC5EB0012785A /* Info.plist */,
 			);
 			path = iOSEngineerCodeCheckTests;
@@ -296,6 +299,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B69AD34F2B77A9450051CC84 /* github-repositories.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		B69AD34B2B779B6E0051CC84 /* NavigationRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD34A2B779B6E0051CC84 /* NavigationRouterTests.swift */; };
 		B69AD34D2B77A5F50051CC84 /* URLSessionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD34C2B77A5F50051CC84 /* URLSessionExtension.swift */; };
 		B69AD34F2B77A9450051CC84 /* github-repositories.json in Resources */ = {isa = PBXBuildFile; fileRef = B69AD34E2B77A9450051CC84 /* github-repositories.json */; };
+		B69AD3512B77A9A20051CC84 /* GitHubAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3502B77A9A20051CC84 /* GitHubAPIClientTests.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -72,6 +73,7 @@
 		B69AD34A2B779B6E0051CC84 /* NavigationRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouterTests.swift; sourceTree = "<group>"; };
 		B69AD34C2B77A5F50051CC84 /* URLSessionExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionExtension.swift; sourceTree = "<group>"; };
 		B69AD34E2B77A9450051CC84 /* github-repositories.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "github-repositories.json"; sourceTree = "<group>"; };
+		B69AD3502B77A9A20051CC84 /* GitHubAPIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIClientTests.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -167,6 +169,7 @@
 				B636A9062B766A320084CD0A /* GitHubRepositoryTests.swift */,
 				B636A90E2B76FA9C0084CD0A /* GitHubSearcherTests.swift */,
 				B69AD34A2B779B6E0051CC84 /* NavigationRouterTests.swift */,
+				B69AD3502B77A9A20051CC84 /* GitHubAPIClientTests.swift */,
 				B636A9002B7506920084CD0A /* TestError.swift */,
 				B636A9122B76FC0F0084CD0A /* GitHubRepositoryExtension.swift */,
 				B69AD34E2B77A9450051CC84 /* github-repositories.json */,
@@ -363,6 +366,7 @@
 				B636A9132B76FC0F0084CD0A /* GitHubRepositoryExtension.swift in Sources */,
 				B636A9072B766A320084CD0A /* GitHubRepositoryTests.swift in Sources */,
 				B636A8FF2B75006C0084CD0A /* ImageCacheTests.swift in Sources */,
+				B69AD3512B77A9A20051CC84 /* GitHubAPIClientTests.swift in Sources */,
 				B636A9012B7506920084CD0A /* TestError.swift in Sources */,
 				B636A90F2B76FA9C0084CD0A /* GitHubSearcherTests.swift in Sources */,
 				B636A8FD2B74FC5B0084CD0A /* ImageCacheStateTests.swift in Sources */,

--- a/iOSEngineerCodeCheck/GitHubAPIClient.swift
+++ b/iOSEngineerCodeCheck/GitHubAPIClient.swift
@@ -15,7 +15,7 @@ actor GitHubAPIClient: GitHubAPIClientForSearcher {
         self.urlSession = urlSession
     }
 
-    func fetchRepositories(word: String) async throws -> [GitHubRepository] {
+    func searchRepositories(word: String) async throws -> [GitHubRepository] {
         var components = URLComponents(string: "https://api.github.com/search/repositories")!
         components.queryItems = [.init(name: "q", value: word)]
 

--- a/iOSEngineerCodeCheck/GitHubAPIClient.swift
+++ b/iOSEngineerCodeCheck/GitHubAPIClient.swift
@@ -30,6 +30,6 @@ actor GitHubAPIClient: GitHubAPIClientForSearcher {
 
         let repositories = try decoder.decode(GitHubRepositories.self, from: data)
 
-        return repositories.items ?? []
+        return repositories.items
     }
 }

--- a/iOSEngineerCodeCheck/GitHubAPIClient.swift
+++ b/iOSEngineerCodeCheck/GitHubAPIClient.swift
@@ -1,8 +1,18 @@
 import Foundation
 
+protocol URLSessionForGitHubAPIClient {
+    func data(for url: URL) async throws -> Data
+}
+
 actor GitHubAPIClient: GitHubAPIClientForSearcher {
     enum FetchError: Error {
         case makeUrlFailed
+    }
+
+    private let urlSession: URLSessionForGitHubAPIClient
+
+    init(urlSession: URLSessionForGitHubAPIClient = URLSession.shared) {
+        self.urlSession = urlSession
     }
 
     func fetchRepositories(word: String) async throws -> [GitHubRepository] {
@@ -13,7 +23,7 @@ actor GitHubAPIClient: GitHubAPIClientForSearcher {
             throw FetchError.makeUrlFailed
         }
 
-        let (data, _) = try await URLSession.shared.data(for: .init(url: url))
+        let data = try await urlSession.data(for: url)
 
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/iOSEngineerCodeCheck/GitHubRepository.swift
+++ b/iOSEngineerCodeCheck/GitHubRepository.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct GitHubRepositories: Decodable {
-    let items: [GitHubRepository]?
+    let items: [GitHubRepository]
 }
 
 struct GitHubRepository: Decodable, Equatable {

--- a/iOSEngineerCodeCheck/GitHubSearcher.swift
+++ b/iOSEngineerCodeCheck/GitHubSearcher.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 protocol GitHubAPIClientForSearcher {
-    func fetchRepositories(word: String) async throws -> [GitHubRepository]
+    func searchRepositories(word: String) async throws -> [GitHubRepository]
 }
 
 @MainActor
@@ -29,7 +29,7 @@ final class GitHubSearcher {
 
         let task = Task {
             do {
-                let repositories = try await apiClient.fetchRepositories(word: word)
+                let repositories = try await apiClient.searchRepositories(word: word)
                 state = .loaded(repositories)
             } catch {
                 state = .failed(error, state.repositories)

--- a/iOSEngineerCodeCheck/URLSessionExtension.swift
+++ b/iOSEngineerCodeCheck/URLSessionExtension.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension URLSession: URLSessionForGitHubAPIClient {
+    func data(for url: URL) async throws -> Data {
+        try await data(for: .init(url: url), delegate: nil).0
+    }
+}

--- a/iOSEngineerCodeCheckTests/GitHubAPIClientTests.swift
+++ b/iOSEngineerCodeCheckTests/GitHubAPIClientTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+
+@testable import iOSEngineerCodeCheck
+
+private actor URLSessionSuccessMock: URLSessionForGitHubAPIClient {
+    var receivedURL: URL?
+
+    func data(for url: URL) async throws -> Data {
+        receivedURL = url
+
+        let jsonUrl = Bundle(for: Self.self).url(
+            forResource: "github-repositories", withExtension: "json")!
+        let json = try String(contentsOf: jsonUrl, encoding: .utf8)
+        return json.data(using: .utf8)!
+    }
+}
+
+private actor URLSessionFailureMock: URLSessionForGitHubAPIClient {
+    func data(for url: URL) async throws -> Data {
+        return Data()
+    }
+}
+
+final class GitHubAPIClientTests: XCTestCase {
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func test_検索に成功しデータが返る() async throws {
+        let urlSession = URLSessionSuccessMock()
+        let apiClient = GitHubAPIClient(urlSession: urlSession)
+
+        let repositories = try await apiClient.searchRepositories(word: "test-word")
+
+        let receivedURL = await urlSession.receivedURL
+        XCTAssertEqual(
+            receivedURL?.absoluteString, "https://api.github.com/search/repositories?q=test-word")
+
+        let expected: [GitHubRepository] = [
+            .init(
+                fullName: "full-name-1", language: "PHP",
+                owner: .init(avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4"),
+                stargazersCount: 101, watchersCount: 102, forksCount: 103, openIssuesCount: 104),
+            .init(
+                fullName: "full-name-2", language: "Java",
+                owner: .init(avatarUrl: "https://avatars.githubusercontent.com/u/2?v=4"),
+                stargazersCount: 201, watchersCount: 202, forksCount: 203, openIssuesCount: 204),
+        ]
+
+        XCTAssertEqual(repositories, expected)
+    }
+
+    func test_検索に失敗しエラーが返る() async throws {
+        let urlSession = URLSessionFailureMock()
+        let apiClient = GitHubAPIClient(urlSession: urlSession)
+
+        do {
+            _ = try await apiClient.searchRepositories(word: "test-word")
+            XCTFail()
+        } catch {
+            // OK
+        }
+    }
+}

--- a/iOSEngineerCodeCheckTests/GitHubSearcherTests.swift
+++ b/iOSEngineerCodeCheckTests/GitHubSearcherTests.swift
@@ -9,7 +9,7 @@ private actor APIClientMock: GitHubAPIClientForSearcher {
         self.result = result
     }
 
-    func fetchRepositories(word: String) async throws -> [GitHubRepository] {
+    func searchRepositories(word: String) async throws -> [GitHubRepository] {
         try result.get()
     }
 }

--- a/iOSEngineerCodeCheckTests/github-repositories.json
+++ b/iOSEngineerCodeCheckTests/github-repositories.json
@@ -1,0 +1,30 @@
+{
+    "items": [
+        {
+            "id": 1,
+            "full_name": "full-name-1",
+            "owner": {
+                "id": 10,
+                "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4"
+            },
+            "stargazers_count": 101,
+            "watchers_count": 102,
+            "language": "PHP",
+            "forks_count": 103,
+            "open_issues_count": 104
+        },
+        {
+            "id": 2,
+            "full_name": "full-name-2",
+            "owner": {
+                "id": 20,
+                "avatar_url": "https://avatars.githubusercontent.com/u/2?v=4"
+            },
+            "stargazers_count": 201,
+            "watchers_count": 202,
+            "language": "Java",
+            "forks_count": 203,
+            "open_issues_count": 204
+        }
+    ]
+}


### PR DESCRIPTION
#9 に関する変更。
GitHubAPIClientが呼び出しているURLSessionのメソッドをプロトコルで定義して差し替えられるようにして、GitHubAPIClientのテストをします。