### PR TITLE
アプリ全体を管理するクラスを追加

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		B69AD34D2B77A5F50051CC84 /* URLSessionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD34C2B77A5F50051CC84 /* URLSessionExtension.swift */; };
 		B69AD34F2B77A9450051CC84 /* github-repositories.json in Resources */ = {isa = PBXBuildFile; fileRef = B69AD34E2B77A9450051CC84 /* github-repositories.json */; };
 		B69AD3512B77A9A20051CC84 /* GitHubAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3502B77A9A20051CC84 /* GitHubAPIClientTests.swift */; };
+		B69AD3532B7848FF0051CC84 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3522B7848FF0051CC84 /* App.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -74,6 +75,7 @@
 		B69AD34C2B77A5F50051CC84 /* URLSessionExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionExtension.swift; sourceTree = "<group>"; };
 		B69AD34E2B77A9450051CC84 /* github-repositories.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "github-repositories.json"; sourceTree = "<group>"; };
 		B69AD3502B77A9A20051CC84 /* GitHubAPIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIClientTests.swift; sourceTree = "<group>"; };
+		B69AD3522B7848FF0051CC84 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -141,6 +143,7 @@
 			children = (
 				BFD945DE244DC5E80012785A /* AppDelegate.swift */,
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
+				B69AD3522B7848FF0051CC84 /* App.swift */,
 				B636A9162B77558E0084CD0A /* RootNavigationController.swift */,
 				B636A9182B7756090084CD0A /* NavigationRouter.swift */,
 				BFD945E2244DC5E80012785A /* MainViewController.swift */,
@@ -344,6 +347,7 @@
 				BFD945E3244DC5E80012785A /* MainViewController.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */,
 				B636A9152B770EBB0084CD0A /* GitHubSearcherState.swift in Sources */,
+				B69AD3532B7848FF0051CC84 /* App.swift in Sources */,
 				B636A90D2B76F40B0084CD0A /* GitHubSearcher.swift in Sources */,
 				B636A8F92B74F3730084CD0A /* ImageCache.swift in Sources */,
 				B636A9172B77558E0084CD0A /* RootNavigationController.swift in Sources */,

--- a/iOSEngineerCodeCheck/App.swift
+++ b/iOSEngineerCodeCheck/App.swift
@@ -5,4 +5,5 @@ final class App {
     static let shared: App = .init()
 
     let router: NavigationRouter = .init()
+    let searcher: GitHubSearcher = .init()
 }

--- a/iOSEngineerCodeCheck/App.swift
+++ b/iOSEngineerCodeCheck/App.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+final class App {
+    static let shared: App = .init()
+}

--- a/iOSEngineerCodeCheck/App.swift
+++ b/iOSEngineerCodeCheck/App.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+@MainActor
 final class App {
     static let shared: App = .init()
+
+    let router: NavigationRouter = .init()
 }

--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -15,10 +15,14 @@ class DetailViewController: UIViewController {
 
     private var cancellables: Set<AnyCancellable> = []
 
-    static func make(repository: GitHubRepository) -> DetailViewController {
+    static func make(repositoryIndex: Int) -> DetailViewController? {
+        let repositories = App.shared.searcher.state.repositories
+
+        guard repositoryIndex < repositories.count else { return nil }
+
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let detail = storyboard.instantiateViewController(identifier: "Detail") { coder in
-            DetailViewController(coder: coder, repository: repository)
+            DetailViewController(coder: coder, repository: repositories[repositoryIndex])
         }
         return detail
     }

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -64,10 +64,7 @@ class MainViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard indexPath.row < repositories.count else { return }
-
-        let repository = repositories[indexPath.row]
-        router.showDetail(.init(repository: repository))
+        router.showDetail(.init(repositoryIndex: indexPath.row))
     }
 }
 

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -5,20 +5,22 @@ class MainViewController: UITableViewController {
     @IBOutlet weak var searchBar: UISearchBar!
 
     private unowned let router: NavigationRouter
-    private let searcher: GitHubSearcher = .init()
+    private unowned let searcher: GitHubSearcher
     private var cancellables: Set<AnyCancellable> = []
     private var repositories: [GitHubRepository] { searcher.state.repositories }
 
     static func make() -> MainViewController {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let main = storyboard.instantiateViewController(identifier: "Main") { coder in
-            MainViewController(coder: coder, router: App.shared.router)
+            MainViewController(
+                coder: coder, router: App.shared.router, searcher: App.shared.searcher)
         }
         return main
     }
 
-    required init?(coder: NSCoder, router: NavigationRouter) {
+    required init?(coder: NSCoder, router: NavigationRouter, searcher: GitHubSearcher) {
         self.router = router
+        self.searcher = searcher
         super.init(coder: coder)
     }
 

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -4,15 +4,15 @@ import UIKit
 class MainViewController: UITableViewController {
     @IBOutlet weak var searchBar: UISearchBar!
 
-    private let router: NavigationRouter
+    private unowned let router: NavigationRouter
     private let searcher: GitHubSearcher = .init()
     private var cancellables: Set<AnyCancellable> = []
     private var repositories: [GitHubRepository] { searcher.state.repositories }
 
-    static func make(router: NavigationRouter) -> MainViewController {
+    static func make() -> MainViewController {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let main = storyboard.instantiateViewController(identifier: "Main") { coder in
-            MainViewController(coder: coder, router: router)
+            MainViewController(coder: coder, router: App.shared.router)
         }
         return main
     }

--- a/iOSEngineerCodeCheck/NavigationRouter.swift
+++ b/iOSEngineerCodeCheck/NavigationRouter.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 struct NavigationDetail: Equatable {
-    let repository: GitHubRepository
+    let repositoryIndex: Int
 }
 
 enum NavigationRouterState {

--- a/iOSEngineerCodeCheck/RootNavigationController.swift
+++ b/iOSEngineerCodeCheck/RootNavigationController.swift
@@ -2,7 +2,7 @@ import Combine
 import UIKit
 
 class RootNavigationController: UINavigationController {
-    private let router: NavigationRouter = .init()
+    private unowned let router: NavigationRouter = App.shared.router
     private var cancellables: Set<AnyCancellable> = []
 
     override func viewDidLoad() {
@@ -33,7 +33,7 @@ class RootNavigationController: UINavigationController {
     private func makeViewController(element: NavigationElement) -> UIViewController {
         switch element {
         case .main:
-            MainViewController.make(router: router)
+            MainViewController.make()
         case let .detail(detail):
             DetailViewController.make(repository: detail.repository)
         }

--- a/iOSEngineerCodeCheck/RootNavigationController.swift
+++ b/iOSEngineerCodeCheck/RootNavigationController.swift
@@ -23,19 +23,20 @@ class RootNavigationController: UINavigationController {
         } else if previousCount < elements.count {
             var viewControllers = viewControllers
             for index in previousCount..<elements.count {
-                let viewController = makeViewController(element: elements[index])
-                viewControllers.append(viewController)
+                if let viewController = makeViewController(element: elements[index]) {
+                    viewControllers.append(viewController)
+                }
             }
             setViewControllers(viewControllers, animated: true)
         }
     }
 
-    private func makeViewController(element: NavigationElement) -> UIViewController {
+    private func makeViewController(element: NavigationElement) -> UIViewController? {
         switch element {
         case .main:
             MainViewController.make()
         case let .detail(detail):
-            DetailViewController.make(repository: detail.repository)
+            DetailViewController.make(repositoryIndex: detail.repositoryIndex)
         }
     }
 }

--- a/iOSEngineerCodeCheckTests/NavigationRouterTests.swift
+++ b/iOSEngineerCodeCheckTests/NavigationRouterTests.swift
@@ -15,7 +15,7 @@ final class NavigationRouterTests: XCTestCase {
         XCTAssertEqual(router.elements, [.main])
 
         XCTContext.runActivity(named: "Mainが表示される前はDetailに遷移できない") { _ in
-            router.showDetail(.init(repository: .init(testFullName: "pre_appear")))
+            router.showDetail(.init(repositoryIndex: 0))
 
             XCTAssertEqual(router.elements, [.main])
         }
@@ -25,19 +25,19 @@ final class NavigationRouterTests: XCTestCase {
 
             XCTAssertEqual(router.elements, [.main])
 
-            router.showDetail(.init(repository: .init(testFullName: "main_appeared")))
+            router.showDetail(.init(repositoryIndex: 1))
 
             XCTAssertEqual(
                 router.elements,
-                [.main, .detail(.init(repository: .init(testFullName: "main_appeared")))])
+                [.main, .detail(.init(repositoryIndex: 1))])
         }
 
         XCTContext.runActivity(named: "Detail表示中は重複して遷移できない") { _ in
-            router.showDetail(.init(repository: .init(testFullName: "detail_appeared")))
+            router.showDetail(.init(repositoryIndex: 2))
 
             XCTAssertEqual(
                 router.elements,
-                [.main, .detail(.init(repository: .init(testFullName: "main_appeared")))])
+                [.main, .detail(.init(repositoryIndex: 1))])
         }
 
         XCTContext.runActivity(named: "Detail表示中にMainに戻る") { _ in
@@ -47,11 +47,11 @@ final class NavigationRouterTests: XCTestCase {
         }
 
         XCTContext.runActivity(named: "Mainに戻ったらDetailに遷移できる") { _ in
-            router.showDetail(.init(repository: .init(testFullName: "main_appeared")))
+            router.showDetail(.init(repositoryIndex: 3))
 
             XCTAssertEqual(
                 router.elements,
-                [.main, .detail(.init(repository: .init(testFullName: "main_appeared")))])
+                [.main, .detail(.init(repositoryIndex: 3))])
         }
     }
 
@@ -76,12 +76,12 @@ final class NavigationRouterTests: XCTestCase {
         }
 
         XCTContext.runActivity(named: "詳細画面が表示される・detailが追加") { _ in
-            router.showDetail(.init(repository: .init(testFullName: "show_detail")))
+            router.showDetail(.init(repositoryIndex: 0))
 
             XCTAssertEqual(received.count, 2)
             XCTAssertEqual(
                 received[1],
-                [.main, .detail(.init(repository: .init(testFullName: "show_detail")))])
+                [.main, .detail(.init(repositoryIndex: 0))])
         }
 
         XCTContext.runActivity(named: "メイン画面に戻る・detailが削除") { _ in


### PR DESCRIPTION
アプリ全体で必要なオブジェクトの管理を行うAppクラスを追加します。
オブジェクト保持の責務を分け、画面間の依存も軽くします。あとでUIテストを行うことも考えての変更でもあります。