### PR TITLE
MainVCにPresenterとControllerを導入

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		B69AD3532B7848FF0051CC84 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3522B7848FF0051CC84 /* App.swift */; };
 		B69AD3552B7854050051CC84 /* MainPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3542B7854050051CC84 /* MainPresenter.swift */; };
 		B69AD3572B7855F50051CC84 /* MainCellContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3562B7855F50051CC84 /* MainCellContent.swift */; };
+		B69AD3592B7866AA0051CC84 /* MainController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3582B7866AA0051CC84 /* MainController.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -80,6 +81,7 @@
 		B69AD3522B7848FF0051CC84 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		B69AD3542B7854050051CC84 /* MainPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPresenter.swift; sourceTree = "<group>"; };
 		B69AD3562B7855F50051CC84 /* MainCellContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCellContent.swift; sourceTree = "<group>"; };
+		B69AD3582B7866AA0051CC84 /* MainController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainController.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 				B636A9182B7756090084CD0A /* NavigationRouter.swift */,
 				BFD945E2244DC5E80012785A /* MainViewController.swift */,
 				B69AD3542B7854050051CC84 /* MainPresenter.swift */,
+				B69AD3582B7866AA0051CC84 /* MainController.swift */,
 				B69AD3562B7855F50051CC84 /* MainCellContent.swift */,
 				BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */,
 				B636A8F82B74F3730084CD0A /* ImageCache.swift */,
@@ -354,6 +357,7 @@
 				BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */,
 				B636A9152B770EBB0084CD0A /* GitHubSearcherState.swift in Sources */,
 				B69AD3532B7848FF0051CC84 /* App.swift in Sources */,
+				B69AD3592B7866AA0051CC84 /* MainController.swift in Sources */,
 				B636A90D2B76F40B0084CD0A /* GitHubSearcher.swift in Sources */,
 				B636A8F92B74F3730084CD0A /* ImageCache.swift in Sources */,
 				B636A9172B77558E0084CD0A /* RootNavigationController.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		B69AD34F2B77A9450051CC84 /* github-repositories.json in Resources */ = {isa = PBXBuildFile; fileRef = B69AD34E2B77A9450051CC84 /* github-repositories.json */; };
 		B69AD3512B77A9A20051CC84 /* GitHubAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3502B77A9A20051CC84 /* GitHubAPIClientTests.swift */; };
 		B69AD3532B7848FF0051CC84 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3522B7848FF0051CC84 /* App.swift */; };
+		B69AD3552B7854050051CC84 /* MainPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3542B7854050051CC84 /* MainPresenter.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -76,6 +77,7 @@
 		B69AD34E2B77A9450051CC84 /* github-repositories.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "github-repositories.json"; sourceTree = "<group>"; };
 		B69AD3502B77A9A20051CC84 /* GitHubAPIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIClientTests.swift; sourceTree = "<group>"; };
 		B69AD3522B7848FF0051CC84 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
+		B69AD3542B7854050051CC84 /* MainPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPresenter.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -147,6 +149,7 @@
 				B636A9162B77558E0084CD0A /* RootNavigationController.swift */,
 				B636A9182B7756090084CD0A /* NavigationRouter.swift */,
 				BFD945E2244DC5E80012785A /* MainViewController.swift */,
+				B69AD3542B7854050051CC84 /* MainPresenter.swift */,
 				BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */,
 				B636A8F82B74F3730084CD0A /* ImageCache.swift */,
 				B636A8FA2B74FB400084CD0A /* ImageCacheState.swift */,
@@ -355,6 +358,7 @@
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				B69AD34D2B77A5F50051CC84 /* URLSessionExtension.swift in Sources */,
 				B636A8F52B74B6720084CD0A /* GitHubAPIClient.swift in Sources */,
+				B69AD3552B7854050051CC84 /* MainPresenter.swift in Sources */,
 				B636A8F32B74AA9A0084CD0A /* ImageDownloader.swift in Sources */,
 				B636A9192B77560A0084CD0A /* NavigationRouter.swift in Sources */,
 				B636A8FB2B74FB400084CD0A /* ImageCacheState.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		B69AD3512B77A9A20051CC84 /* GitHubAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3502B77A9A20051CC84 /* GitHubAPIClientTests.swift */; };
 		B69AD3532B7848FF0051CC84 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3522B7848FF0051CC84 /* App.swift */; };
 		B69AD3552B7854050051CC84 /* MainPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3542B7854050051CC84 /* MainPresenter.swift */; };
+		B69AD3572B7855F50051CC84 /* MainCellContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3562B7855F50051CC84 /* MainCellContent.swift */; };
 		BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
@@ -78,6 +79,7 @@
 		B69AD3502B77A9A20051CC84 /* GitHubAPIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIClientTests.swift; sourceTree = "<group>"; };
 		B69AD3522B7848FF0051CC84 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		B69AD3542B7854050051CC84 /* MainPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPresenter.swift; sourceTree = "<group>"; };
+		B69AD3562B7855F50051CC84 /* MainCellContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCellContent.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 				B636A9182B7756090084CD0A /* NavigationRouter.swift */,
 				BFD945E2244DC5E80012785A /* MainViewController.swift */,
 				B69AD3542B7854050051CC84 /* MainPresenter.swift */,
+				B69AD3562B7855F50051CC84 /* MainCellContent.swift */,
 				BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */,
 				B636A8F82B74F3730084CD0A /* ImageCache.swift */,
 				B636A8FA2B74FB400084CD0A /* ImageCacheState.swift */,
@@ -354,6 +357,7 @@
 				B636A90D2B76F40B0084CD0A /* GitHubSearcher.swift in Sources */,
 				B636A8F92B74F3730084CD0A /* ImageCache.swift in Sources */,
 				B636A9172B77558E0084CD0A /* RootNavigationController.swift in Sources */,
+				B69AD3572B7855F50051CC84 /* MainCellContent.swift in Sources */,
 				B636A8F12B749DD40084CD0A /* GitHubRepository.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				B69AD34D2B77A5F50051CC84 /* URLSessionExtension.swift in Sources */,

--- a/iOSEngineerCodeCheck/MainCellContent.swift
+++ b/iOSEngineerCodeCheck/MainCellContent.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct MainCellContent {
+    let fullName: String?
+    let language: String?
+}

--- a/iOSEngineerCodeCheck/MainController.swift
+++ b/iOSEngineerCodeCheck/MainController.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+@MainActor
+final class MainController {
+    private unowned let router: NavigationRouter
+    private unowned let searcher: GitHubSearcher
+
+    init(router: NavigationRouter, searcher: GitHubSearcher) {
+        self.router = router
+        self.searcher = searcher
+    }
+
+    func search(word: String) {
+        searcher.search(word: word)
+    }
+
+    func cancelSearch() {
+        searcher.cancel()
+    }
+
+    func didAppear() {
+        router.mainDidAppear()
+    }
+
+    func showDetail(at index: Int) {
+        router.showDetail(.init(repositoryIndex: index))
+    }
+}

--- a/iOSEngineerCodeCheck/MainPresenter.swift
+++ b/iOSEngineerCodeCheck/MainPresenter.swift
@@ -1,0 +1,37 @@
+import Combine
+import Foundation
+
+@MainActor
+final class MainPresenter {
+    private unowned let router: NavigationRouter
+    private unowned let searcher: GitHubSearcher
+
+    var repositories: [GitHubRepository] {
+        searcher.state.repositories
+    }
+
+    var repositoriesPublisher: AnyPublisher<[GitHubRepository], Never> {
+        searcher.statePublisher.map(\.repositories).eraseToAnyPublisher()
+    }
+
+    init(router: NavigationRouter, searcher: GitHubSearcher) {
+        self.router = router
+        self.searcher = searcher
+    }
+
+    func search(word: String) {
+        searcher.search(word: word)
+    }
+
+    func cancelSearch() {
+        searcher.cancel()
+    }
+
+    func didAppear() {
+        router.mainDidAppear()
+    }
+
+    func showDetail(at index: Int) {
+        router.showDetail(.init(repositoryIndex: index))
+    }
+}

--- a/iOSEngineerCodeCheck/MainPresenter.swift
+++ b/iOSEngineerCodeCheck/MainPresenter.swift
@@ -3,7 +3,6 @@ import Foundation
 
 @MainActor
 final class MainPresenter {
-    private unowned let router: NavigationRouter
     private unowned let searcher: GitHubSearcher
 
     private let contentsSubject: CurrentValueSubject<[MainCellContent], Never> = .init([])
@@ -14,28 +13,11 @@ final class MainPresenter {
 
     private var cancellables: Set<AnyCancellable> = []
 
-    init(router: NavigationRouter, searcher: GitHubSearcher) {
-        self.router = router
+    init(searcher: GitHubSearcher) {
         self.searcher = searcher
 
         searcher.statePublisher.map(\.mainCellContents).subscribe(contentsSubject).store(
             in: &cancellables)
-    }
-
-    func search(word: String) {
-        searcher.search(word: word)
-    }
-
-    func cancelSearch() {
-        searcher.cancel()
-    }
-
-    func didAppear() {
-        router.mainDidAppear()
-    }
-
-    func showDetail(at index: Int) {
-        router.showDetail(.init(repositoryIndex: index))
     }
 }
 

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -52,9 +52,13 @@ class MainViewController: UITableViewController {
         let cell = UITableViewCell()
 
         if indexPath.row < presenter.contents.count {
-            let content = presenter.contents[indexPath.row]
-            cell.textLabel?.text = content.fullName
-            cell.detailTextLabel?.text = content.language
+            let contents = presenter.contents[indexPath.row]
+
+            var configuration = cell.defaultContentConfiguration()
+            configuration.text = contents.fullName
+            configuration.secondaryText = contents.language
+            cell.contentConfiguration = configuration
+
             cell.tag = indexPath.row
         }
 

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -5,6 +5,7 @@ class MainViewController: UITableViewController {
     @IBOutlet weak var searchBar: UISearchBar!
 
     private let presenter: MainPresenter
+    private let controller: MainController
     private var cancellables: Set<AnyCancellable> = []
 
     static func make() -> MainViewController {
@@ -12,13 +13,15 @@ class MainViewController: UITableViewController {
         let main = storyboard.instantiateViewController(identifier: "Main") { coder in
             MainViewController(
                 coder: coder,
-                presenter: .init(router: App.shared.router, searcher: App.shared.searcher))
+                presenter: .init(searcher: App.shared.searcher),
+                controller: .init(router: App.shared.router, searcher: App.shared.searcher))
         }
         return main
     }
 
-    required init?(coder: NSCoder, presenter: MainPresenter) {
+    required init?(coder: NSCoder, presenter: MainPresenter, controller: MainController) {
         self.presenter = presenter
+        self.controller = controller
         super.init(coder: coder)
     }
 
@@ -39,7 +42,7 @@ class MainViewController: UITableViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        presenter.didAppear()
+        controller.didAppear()
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -66,16 +69,16 @@ class MainViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        presenter.showDetail(at: indexPath.row)
+        controller.showDetail(at: indexPath.row)
     }
 }
 
 extension MainViewController: UISearchBarDelegate {
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        presenter.cancelSearch()
+        controller.cancelSearch()
     }
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        presenter.search(word: searchBar.text ?? "")
+        controller.search(word: searchBar.text ?? "")
     }
 }

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -6,7 +6,6 @@ class MainViewController: UITableViewController {
 
     private let presenter: MainPresenter
     private var cancellables: Set<AnyCancellable> = []
-    private var repositories: [GitHubRepository] { presenter.repositories }
 
     static func make() -> MainViewController {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
@@ -33,7 +32,7 @@ class MainViewController: UITableViewController {
         searchBar.placeholder = "GitHubのリポジトリを検索できるよー"
         searchBar.delegate = self
 
-        presenter.repositoriesPublisher.sink { [weak self] _ in
+        presenter.contentsPublisher.sink { [weak self] _ in
             self?.tableView.reloadData()
         }.store(in: &cancellables)
     }
@@ -44,7 +43,7 @@ class MainViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return repositories.count
+        return presenter.contents.count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath)
@@ -52,10 +51,10 @@ class MainViewController: UITableViewController {
     {
         let cell = UITableViewCell()
 
-        if indexPath.row < repositories.count {
-            let repository = repositories[indexPath.row]
-            cell.textLabel?.text = repository.fullName
-            cell.detailTextLabel?.text = repository.language
+        if indexPath.row < presenter.contents.count {
+            let content = presenter.contents[indexPath.row]
+            cell.textLabel?.text = content.fullName
+            cell.detailTextLabel?.text = content.language
             cell.tag = indexPath.row
         }
 


### PR DESCRIPTION
MainViewControllerにInterface AdapterとしてPresenterとControllerを追加し、VCから処理を分割します。
特にMainVCのコード量が減っているわけではないですし、必要ないと感じますが、 #6 を考慮して変更しました。

また、メイン画面のセルをセットアップするコードで言語がセットされていたものの表示されていなかったので、表示されるように修正しました。