### PR TITLE
NavigationRouterのdetail内でImageCacheを保持する

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		B69AD3662B7904980051CC84 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3652B7904980051CC84 /* DetailView.swift */; };
 		B69AD3682B7909560051CC84 /* DetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3672B7909560051CC84 /* DetailPresenter.swift */; };
 		B69AD36A2B790E4E0051CC84 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD3692B790E4E0051CC84 /* DetailViewController.swift */; };
+		B69AD36C2B79B56A0051CC84 /* Detail.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69AD36B2B79B56A0051CC84 /* Detail.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
 		BFD945E3244DC5E80012785A /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E2244DC5E80012785A /* MainViewController.swift */; };
@@ -93,6 +94,7 @@
 		B69AD3652B7904980051CC84 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		B69AD3672B7909560051CC84 /* DetailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailPresenter.swift; sourceTree = "<group>"; };
 		B69AD3692B790E4E0051CC84 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
+		B69AD36B2B79B56A0051CC84 /* Detail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Detail.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BFD945E0244DC5E80012785A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 				BFD945DE244DC5E80012785A /* AppDelegate.swift */,
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
 				B69AD3522B7848FF0051CC84 /* App.swift */,
+				B69AD36B2B79B56A0051CC84 /* Detail.swift */,
 				B636A9162B77558E0084CD0A /* RootNavigationController.swift */,
 				B636A9182B7756090084CD0A /* NavigationRouter.swift */,
 				BFD945E2244DC5E80012785A /* MainViewController.swift */,
@@ -388,6 +391,7 @@
 				B636A8F32B74AA9A0084CD0A /* ImageDownloader.swift in Sources */,
 				B636A9192B77560A0084CD0A /* NavigationRouter.swift in Sources */,
 				B636A8FB2B74FB400084CD0A /* ImageCacheState.swift in Sources */,
+				B69AD36C2B79B56A0051CC84 /* Detail.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOSEngineerCodeCheck/App.swift
+++ b/iOSEngineerCodeCheck/App.swift
@@ -5,11 +5,17 @@ final class App {
     static let shared: App = .init(uiTestContext: .environmentValue)
 
     private let uiTestContext: UITestContext?
-    let router: NavigationRouter = .init()
+    let imageCacheFactory: ImageCacheFactory
+    let router: NavigationRouter
     let searcher: GitHubSearcher
 
     init(uiTestContext: UITestContext?) {
         self.uiTestContext = uiTestContext
+
+        let imageCacheFactory = ImageCacheFactory(isTest: uiTestContext != nil)
+        self.imageCacheFactory = imageCacheFactory
+
+        router = .init(imageCacheFactory: imageCacheFactory)
 
         if let uiTestContext {
             self.searcher = .init(
@@ -19,9 +25,8 @@ final class App {
         }
     }
 
-    func makeImageCache() -> ImageCache {
-        let downloader: DownloaderForImageCache =
-            App.shared.uiTestContext == nil ? ImageDownloader() : ImageDownloaderUITestMock()
-        return ImageCache(downloader: downloader)
+    var detail: Detail? {
+        guard case let .detail(detail) = router.state else { return nil }
+        return detail
     }
 }

--- a/iOSEngineerCodeCheck/Detail.swift
+++ b/iOSEngineerCodeCheck/Detail.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct Detail {
+    let repositoryIndex: Int
+    let imageCache: ImageCache
+}

--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -4,11 +4,12 @@ class DetailViewController: UIHostingController<DetailView> {
     static func make(repositoryIndex: Int) -> DetailViewController? {
         let repositories = App.shared.searcher.state.repositories
 
-        guard repositoryIndex < repositories.count else { return nil }
+        guard let detail = App.shared.detail, detail.repositoryIndex == repositoryIndex,
+            repositoryIndex < repositories.count
+        else { return nil }
 
-        let imageCache = App.shared.makeImageCache()
         let presenter = DetailPresenter(
-            repository: repositories[repositoryIndex], imageCache: imageCache)
+            repository: repositories[repositoryIndex], imageCache: detail.imageCache)
 
         return .init(rootView: .init(presenter: presenter))
     }

--- a/iOSEngineerCodeCheck/ImageCache.swift
+++ b/iOSEngineerCodeCheck/ImageCache.swift
@@ -42,3 +42,18 @@ final class ImageCache: ImageCacheForPresenter {
         }
     }
 }
+
+@MainActor
+final class ImageCacheFactory {
+    private let isTest: Bool
+
+    init(isTest: Bool) {
+        self.isTest = isTest
+    }
+
+    func makeImageCache() -> ImageCache {
+        let downloader: DownloaderForImageCache =
+            isTest ? ImageDownloaderUITestMock() : ImageDownloader()
+        return ImageCache(downloader: downloader)
+    }
+}

--- a/iOSEngineerCodeCheck/MainController.swift
+++ b/iOSEngineerCodeCheck/MainController.swift
@@ -23,6 +23,6 @@ final class MainController {
     }
 
     func showDetail(at index: Int) {
-        router.showDetail(.init(repositoryIndex: index))
+        router.showDetail(repositoryIndex: index)
     }
 }

--- a/iOSEngineerCodeCheckTests/NavigationRouterTests.swift
+++ b/iOSEngineerCodeCheckTests/NavigationRouterTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import iOSEngineerCodeCheck
 
+@MainActor
 final class NavigationRouterTests: XCTestCase {
     override func setUpWithError() throws {
     }
@@ -10,12 +11,13 @@ final class NavigationRouterTests: XCTestCase {
     }
 
     func test_遷移() {
-        let router = NavigationRouter()
+        let factory = ImageCacheFactory(isTest: true)
+        let router = NavigationRouter(imageCacheFactory: factory)
 
         XCTAssertEqual(router.elements, [.main])
 
         XCTContext.runActivity(named: "Mainが表示される前はDetailに遷移できない") { _ in
-            router.showDetail(.init(repositoryIndex: 0))
+            router.showDetail(repositoryIndex: 0)
 
             XCTAssertEqual(router.elements, [.main])
         }
@@ -25,7 +27,7 @@ final class NavigationRouterTests: XCTestCase {
 
             XCTAssertEqual(router.elements, [.main])
 
-            router.showDetail(.init(repositoryIndex: 1))
+            router.showDetail(repositoryIndex: 1)
 
             XCTAssertEqual(
                 router.elements,
@@ -33,7 +35,7 @@ final class NavigationRouterTests: XCTestCase {
         }
 
         XCTContext.runActivity(named: "Detail表示中は重複して遷移できない") { _ in
-            router.showDetail(.init(repositoryIndex: 2))
+            router.showDetail(repositoryIndex: 2)
 
             XCTAssertEqual(
                 router.elements,
@@ -47,7 +49,7 @@ final class NavigationRouterTests: XCTestCase {
         }
 
         XCTContext.runActivity(named: "Mainに戻ったらDetailに遷移できる") { _ in
-            router.showDetail(.init(repositoryIndex: 3))
+            router.showDetail(repositoryIndex: 3)
 
             XCTAssertEqual(
                 router.elements,
@@ -56,7 +58,8 @@ final class NavigationRouterTests: XCTestCase {
     }
 
     func test_elementsの購読() {
-        let router = NavigationRouter()
+        let factory = ImageCacheFactory(isTest: true)
+        let router = NavigationRouter(imageCacheFactory: factory)
 
         var received: [[NavigationElement]] = []
 
@@ -76,7 +79,7 @@ final class NavigationRouterTests: XCTestCase {
         }
 
         XCTContext.runActivity(named: "詳細画面が表示される・detailが追加") { _ in
-            router.showDetail(.init(repositoryIndex: 0))
+            router.showDetail(repositoryIndex: 0)
 
             XCTAssertEqual(received.count, 2)
             XCTAssertEqual(


### PR DESCRIPTION
#5 に関する変更。
リポジトリ詳細画面で使われるImageCacheを、VC側で生成するのではなくNavigationRouter側で生成して保持します。